### PR TITLE
Pattern selection

### DIFF
--- a/pattern-language-editor-client/src/state/patterns/index.ts
+++ b/pattern-language-editor-client/src/state/patterns/index.ts
@@ -1,5 +1,5 @@
-import { patternsSlice, selectpattarnSlice } from './slice'
+import { patternsSlice } from './slice'
 
 export const patternsReducer = patternsSlice.reducer
-export const selectpattarnReducer = selectpattarnSlice.reducer
-export { patternsSelector, patternNamesSelector } from './selector'
+export const { select } = patternsSlice.actions
+export { patternsSelector, selectedPatternSelector, patternNamesSelector } from './selector'

--- a/pattern-language-editor-client/src/state/patterns/index.ts
+++ b/pattern-language-editor-client/src/state/patterns/index.ts
@@ -1,4 +1,5 @@
-import { patternsSlice } from './slice'
+import { patternsSlice, selectpattarnSlice } from './slice'
 
 export const patternsReducer = patternsSlice.reducer
+export const selectpattarnReducer = selectpattarnSlice.reducer
 export { patternsSelector, patternNamesSelector } from './selector'

--- a/pattern-language-editor-client/src/state/patterns/selector.ts
+++ b/pattern-language-editor-client/src/state/patterns/selector.ts
@@ -1,17 +1,34 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { RootState } from '../../store'
+import { Pattern } from './states'
 
 export const patternsSelector = createSelector(
   (state: RootState) => state.patternsReducer.patterns,
   (patterns) => patterns
 )
 
-// ここでidを用いて選択したパターンを返せるようにしたい
-export const patternsSelector2 = createSelector(
-  (state: RootState) => state.patternsReducer.patterns,
-  (patterns) => patterns[0]
+export const selectedPatternSelector = createSelector(
+  (state: RootState) => state.patternsReducer,
+  (state) => {
+    const selecteds = state.patterns.filter((pattern) => pattern.name === state.selectedPatternName)
+
+    if (selecteds.length == 1) {
+      return selecteds[0]
+    } else {
+      return {
+        name: '',
+        imgPath: '',
+        context: '',
+        problem: '',
+        fource: '',
+        solution: '',
+        result: '',
+      } as Pattern
+    }
+  }
 )
 
-export const patternNamesSelector = createSelector(patternsSelector, (patterns) =>
-  patterns.map((pattern) => pattern.name)
+export const patternNamesSelector = createSelector(
+  (state: RootState) => state.patternsReducer.patterns,
+  (patterns) => patterns.map((pattern) => pattern.name)
 )

--- a/pattern-language-editor-client/src/state/patterns/selector.ts
+++ b/pattern-language-editor-client/src/state/patterns/selector.ts
@@ -6,6 +6,12 @@ export const patternsSelector = createSelector(
   (patterns) => patterns
 )
 
+// ここでidを用いて選択したパターンを返せるようにしたい
+export const patternsSelector2 = createSelector(
+  (state: RootState) => state.patternsReducer.patterns,
+  (patterns) => patterns[0]
+)
+
 export const patternNamesSelector = createSelector(patternsSelector, (patterns) =>
   patterns.map((pattern) => pattern.name)
 )

--- a/pattern-language-editor-client/src/state/patterns/slice.ts
+++ b/pattern-language-editor-client/src/state/patterns/slice.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { initialState } from './states'
 
 export const patternsSlice = createSlice({
@@ -6,3 +6,25 @@ export const patternsSlice = createSlice({
   initialState: initialState,
   reducers: {},
 })
+
+export const IdInitialState = {
+  id: 'テスト',
+}
+
+export const selectpattarnSlice = createSlice({
+  name: 'selectpattarn', //スライス名
+  initialState: IdInitialState,
+  // 初期値
+  // reducerを生成
+  reducers: {
+    select: (state, action: PayloadAction<string>) => {
+      state.id = action.payload
+    },
+  },
+})
+
+// コンポーネントからactionをdispatchできるようにexport
+export const { select } = selectpattarnSlice.actions
+
+//リデューサの切り出し
+export const selectpattarnReducer = selectpattarnSlice.reducer

--- a/pattern-language-editor-client/src/state/patterns/slice.ts
+++ b/pattern-language-editor-client/src/state/patterns/slice.ts
@@ -4,27 +4,9 @@ import { initialState } from './states'
 export const patternsSlice = createSlice({
   name: 'patterns',
   initialState: initialState,
-  reducers: {},
-})
-
-export const IdInitialState = {
-  id: 'テスト',
-}
-
-export const selectpattarnSlice = createSlice({
-  name: 'selectpattarn', //スライス名
-  initialState: IdInitialState,
-  // 初期値
-  // reducerを生成
   reducers: {
     select: (state, action: PayloadAction<string>) => {
-      state.id = action.payload
+      state.selectedPatternName = action.payload
     },
   },
 })
-
-// コンポーネントからactionをdispatchできるようにexport
-export const { select } = selectpattarnSlice.actions
-
-//リデューサの切り出し
-export const selectpattarnReducer = selectpattarnSlice.reducer

--- a/pattern-language-editor-client/src/state/patterns/states.ts
+++ b/pattern-language-editor-client/src/state/patterns/states.ts
@@ -36,4 +36,5 @@ export const initialState = {
         '業務改善によって伸ばしたい【業務の付加価値】(1-05)が明確になることで、手段と目的がそぐわない事態を未然に防ぐことができる。',
     },
   ] as Pattern[],
+  selectedPatternName: '',
 }

--- a/pattern-language-editor-client/src/store.ts
+++ b/pattern-language-editor-client/src/store.ts
@@ -1,10 +1,15 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { patternsReducer } from './state/patterns'
+import { patternsReducer, selectpattarnReducer } from './state/patterns'
+import { combineReducers } from 'redux'
+
+//リデューサ
+const reducer = combineReducers({
+  patternsReducer: patternsReducer,
+  selectpattarnReducer: selectpattarnReducer,
+})
 
 export const store = configureStore({
-  reducer: {
-    patternsReducer: patternsReducer,
-  },
+  reducer,
 })
 
 export type AppDispatch = typeof store.dispatch

--- a/pattern-language-editor-client/src/store.ts
+++ b/pattern-language-editor-client/src/store.ts
@@ -1,11 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { patternsReducer, selectpattarnReducer } from './state/patterns'
+import { patternsReducer } from './state/patterns'
 import { combineReducers } from 'redux'
 
 //リデューサ
 const reducer = combineReducers({
   patternsReducer: patternsReducer,
-  selectpattarnReducer: selectpattarnReducer,
 })
 
 export const store = configureStore({

--- a/pattern-language-editor-client/src/views/components/PatternListComponent.tsx
+++ b/pattern-language-editor-client/src/views/components/PatternListComponent.tsx
@@ -1,15 +1,28 @@
 import React from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { RootState, store } from '../../store'
+import { select } from '../../state/patterns/slice'
 
 export type Props = {
   names: string[]
 }
 
 function PatternList(listItem: Props) {
+  const dispatch = useDispatch()
+
   const arr: JSX.Element[] = []
+
+  const onClick = (e: any) => {
+    dispatch(select(e.currentTarget.id))
+  }
 
   if (listItem) {
     listItem.names.forEach((name) => {
-      arr.push(<li key={name}> {name}</li>)
+      arr.push(
+        <li key={name} id={name} onClick={onClick}>
+          {name}
+        </li>
+      )
     })
   }
 

--- a/pattern-language-editor-client/src/views/components/PatternListComponent.tsx
+++ b/pattern-language-editor-client/src/views/components/PatternListComponent.tsx
@@ -1,25 +1,17 @@
 import React from 'react'
-import { useSelector, useDispatch } from 'react-redux'
-import { RootState, store } from '../../store'
-import { select } from '../../state/patterns/slice'
 
 export type Props = {
   names: string[]
+  onPatternSelected: (patternName: string) => void
 }
 
-function PatternList(listItem: Props) {
-  const dispatch = useDispatch()
-
+function PatternList(props: Props) {
   const arr: JSX.Element[] = []
 
-  const onClick = (e: any) => {
-    dispatch(select(e.currentTarget.id))
-  }
-
-  if (listItem) {
-    listItem.names.forEach((name) => {
+  if (props.names) {
+    props.names.forEach((name) => {
       arr.push(
-        <li key={name} id={name} onClick={onClick}>
+        <li key={name} id={name} onClick={() => props.onPatternSelected(name)}>
           {name}
         </li>
       )

--- a/pattern-language-editor-client/src/views/components/PatternViweComponent.tsx
+++ b/pattern-language-editor-client/src/views/components/PatternViweComponent.tsx
@@ -10,34 +10,34 @@ export type Props = {
   result: string
 }
 
-function PatternView({ name, imgPath, context, problem, fource, solution, result }: Props) {
+function PatternView(pattern: Props) {
   return (
     <div>
       <div>
-        <input type="text" defaultValue={name} readOnly={true} />
+        <input type="text" defaultValue={pattern.name} readOnly={true} />
       </div>
       <div>
-        <img src={imgPath} />
+        <img src={pattern.imgPath} />
       </div>
       <div>
         <label>コンテキスト</label>
-        <input type="text" defaultValue={context} readOnly={true} />
+        <input type="text" defaultValue={pattern.context} readOnly={true} />
       </div>
       <div>
         <label>問題</label>
-        <input type="text" defaultValue={problem} readOnly={true} />
+        <input type="text" defaultValue={pattern.problem} readOnly={true} />
       </div>
       <div>
         <label>フォース</label>
-        <input type="text" defaultValue={fource} readOnly={true} />
+        <input type="text" defaultValue={pattern.fource} readOnly={true} />
       </div>
       <div>
         <label>解決策</label>
-        <input type="text" defaultValue={solution} readOnly={true} />
+        <input type="text" defaultValue={pattern.solution} readOnly={true} />
       </div>
       <div>
         <label>結果</label>
-        <input type="text" defaultValue={result} readOnly={true} />
+        <input type="text" defaultValue={pattern.result} readOnly={true} />
       </div>
     </div>
   )

--- a/pattern-language-editor-client/src/views/containers/PatternListContainer.tsx
+++ b/pattern-language-editor-client/src/views/containers/PatternListContainer.tsx
@@ -1,15 +1,16 @@
-import { connect, useSelector } from 'react-redux'
-import PatternList, { Props } from '../components/PatternListComponent'
-import { patternNamesSelector } from '../../state/patterns'
+import { connect } from 'react-redux'
+import PatternList from '../components/PatternListComponent'
+import { patternNamesSelector, select } from '../../state/patterns'
+import { AppDispatch, RootState } from '../../store'
 
-const mapStateToProps = (): Props => {
-  const patternNames = useSelector(patternNamesSelector)
+const mapStateToProps = (state: RootState) => ({
+  names: patternNamesSelector(state),
+})
 
-  return { names: patternNames }
-}
-
-const mapDispatchToProps = () => {
-  return {}
+const mapDispatchToProps = (dispatch: AppDispatch) => {
+  return {
+    onPatternSelected: (patternName: string) => dispatch(select(patternName)),
+  }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(PatternList)

--- a/pattern-language-editor-client/src/views/containers/PatternViewContainer.tsx
+++ b/pattern-language-editor-client/src/views/containers/PatternViewContainer.tsx
@@ -1,28 +1,19 @@
-import { connect, useSelector } from 'react-redux'
-import PatternView, { Props } from '../components/PatternViweComponent'
-import { patternsSelector2 } from '../../state/patterns/selector'
+import { connect } from 'react-redux'
+import PatternView from '../components/PatternViweComponent'
+import { selectedPatternSelector } from '../../state/patterns/selector'
+import { RootState } from '../../store'
 
-const mapStateToProps = (): Props => {
-  // const patterns = useSelector((state: RootState) => state.patternsReducer.patterns)
-
-  const patterns2 = useSelector(patternsSelector2)
+const mapStateToProps = (state: RootState) => {
+  const selected = selectedPatternSelector(state)
 
   return {
-    // name: patterns[0].name,
-    // imgPath: patterns[0].imgPath,
-    // context: patterns[0].context,
-    // problem: patterns[0].problem,
-    // fource: patterns[0].fource,
-    // solution: patterns[0].solution,
-    // result: patterns[0].result,
-
-    name: patterns2.name,
-    imgPath: patterns2.imgPath,
-    context: patterns2.context,
-    problem: patterns2.problem,
-    fource: patterns2.fource,
-    solution: patterns2.solution,
-    result: patterns2.result,
+    name: selected.name,
+    imgPath: selected.imgPath,
+    context: selected.context,
+    problem: selected.problem,
+    fource: selected.fource,
+    solution: selected.solution,
+    result: selected.result,
   }
 }
 

--- a/pattern-language-editor-client/src/views/containers/PatternViewContainer.tsx
+++ b/pattern-language-editor-client/src/views/containers/PatternViewContainer.tsx
@@ -1,18 +1,28 @@
 import { connect, useSelector } from 'react-redux'
 import PatternView, { Props } from '../components/PatternViweComponent'
-import type { RootState } from '../../store'
+import { patternsSelector2 } from '../../state/patterns/selector'
 
 const mapStateToProps = (): Props => {
-  const patterns = useSelector((state: RootState) => state.patternsReducer.patterns)
+  // const patterns = useSelector((state: RootState) => state.patternsReducer.patterns)
+
+  const patterns2 = useSelector(patternsSelector2)
 
   return {
-    name: patterns[0].name,
-    imgPath: patterns[0].imgPath,
-    context: patterns[0].context,
-    problem: patterns[0].problem,
-    fource: patterns[0].fource,
-    solution: patterns[0].solution,
-    result: patterns[0].result,
+    // name: patterns[0].name,
+    // imgPath: patterns[0].imgPath,
+    // context: patterns[0].context,
+    // problem: patterns[0].problem,
+    // fource: patterns[0].fource,
+    // solution: patterns[0].solution,
+    // result: patterns[0].result,
+
+    name: patterns2.name,
+    imgPath: patterns2.imgPath,
+    context: patterns2.context,
+    problem: patterns2.problem,
+    fource: patterns2.fource,
+    solution: patterns2.solution,
+    result: patterns2.result,
   }
 }
 


### PR DESCRIPTION
## チケットへのリンク

#7

## やったこと

画面上部に登録されているパターンの名前の一覧のうちユーザーがクリックしたパターンの内容を表示する。

## やらないこと

見た目の体裁を整えること

## できるようになること（ユーザ目線）

 登録されているパターンの名前の一覧のうち、任意のものをクリックすると、そのパターンの内容が表示できる。

## できなくなること（ユーザ目線）

無し

## 動作確認

`npm start`で実行し、一覧上の任意のパターン名をクリックすることで選択されたパターンが表示されることを確認

## その他
- patternsSliceのreducerにクリックしたパターン名を取得しstate.selectedPatternNameにセットする関数を追加した（select）
- componentsのほうは上位からいわれたイベントをただ呼ぶだけに変更
- containerでuseXXXを呼び出している箇所を修正(下のURLのhookルール違反を直した)
  - https://react.dev/warnings/invalid-hook-call-warning