### PR TITLE
パターンの編集、削除操作の改善

### DIFF
--- a/pattern-language-editor-client/src/views/containers/PatternListContainer.tsx
+++ b/pattern-language-editor-client/src/views/containers/PatternListContainer.tsx
@@ -1,11 +1,21 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState, useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { patternsSelector, select } from '../../state/patterns'
-import { List, ListItemButton, ListItemText } from '@mui/material'
+import { List, ListItemButton, Box, IconButton, Typography } from '@mui/material'
+import EditIcon from '@mui/icons-material/Edit'
+import DeleteIcon from '@mui/icons-material/Delete'
 
-const PatternListContainer = () => {
+type PatternListContainerProps = {
+  onPatternRemoveClicked: (id: number) => void
+  onPatternEditClicked: () => void
+}
+
+const PatternListContainer = (props: PatternListContainerProps) => {
   const patterns = useSelector(patternsSelector)
+  const [selectedIndex, setSelectedIndex] = useState<number | undefined>()
+  const [boxWidth, setBoxWidth] = useState<number | undefined>()
   const dispatch = useDispatch()
+  const buttonBoxRef = useRef<HTMLDivElement>()
 
   const onPatternSelected = useCallback(
     (id: number) => {
@@ -14,13 +24,66 @@ const PatternListContainer = () => {
     [dispatch]
   )
 
+  useEffect(() => {
+    // buttonBoxRefでIconButtonを格納しているboxのサイズを取得→Typographyの表示サイズ変更に利用
+    // この時、ListItemButtonを削除するとbuttonBoxRefの参照がなくなってしまうので、
+    // boxのサイズが取得できているときにstateにキャッシュしておく
+    if (selectedIndex !== undefined && buttonBoxRef.current !== undefined) {
+      setBoxWidth(buttonBoxRef.current?.clientWidth)
+    }
+  }, [selectedIndex])
+
+  // 選択したListItemにIconButtonを表示するため、Typographyの表示領域を調節する
+  const adjustMargin = (myIndex: number) => {
+    if (selectedIndex === myIndex) {
+      return { marginRight: boxWidth }
+    }
+  }
+
   return (
     <List>
-      {patterns.map((pattern) => (
-        <ListItemButton key={pattern.id} onClick={() => onPatternSelected(pattern.id)}>
-          <ListItemText sx={{ textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden' }}>
+      {patterns.map((pattern, index) => (
+        <ListItemButton
+          key={pattern.id}
+          onClick={() => {
+            onPatternSelected(pattern.id)
+            setSelectedIndex(index)
+          }}
+        >
+          <Typography
+            sx={{
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              marginRight: { ...adjustMargin(index) },
+            }}
+          >
             #{pattern.id} {pattern.name}
-          </ListItemText>
+          </Typography>
+          {selectedIndex === index && (
+            <Box
+              ref={buttonBoxRef}
+              top="50%"
+              right={0}
+              position="absolute"
+              sx={{ transform: 'translateY(-50%)' }}
+            >
+              <IconButton
+                onClick={() => {
+                  props.onPatternEditClicked()
+                }}
+              >
+                <EditIcon />
+              </IconButton>
+              <IconButton
+                onClick={() => {
+                  props.onPatternRemoveClicked(pattern.id)
+                }}
+              >
+                <DeleteIcon />
+              </IconButton>
+            </Box>
+          )}
         </ListItemButton>
       ))}
     </List>

--- a/pattern-language-editor-client/src/views/containers/PatternViewContainer.tsx
+++ b/pattern-language-editor-client/src/views/containers/PatternViewContainer.tsx
@@ -1,26 +1,9 @@
-import React, { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
-import { selectedPatternSelector, remove } from '../../state/patterns'
-import Button from '@mui/material/Button'
-import PatternEditDialog from './PatternEditDialogContainer'
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { selectedPatternSelector } from '../../state/patterns'
 
 const PatternViewContainer = () => {
   const selected = useSelector(selectedPatternSelector)
-  const dispatch = useDispatch()
-
-  const [dialogVisible, setDialogVisible] = useState(false)
-
-  const onApplyCreation = (success: boolean) => {
-    if (success) {
-      setDialogVisible(false)
-    } else {
-      // TODO: API失敗したら画面になんか出すとか
-    }
-  }
-
-  const onCancelCreation = () => {
-    setDialogVisible(false)
-  }
 
   return (
     <div>
@@ -51,22 +34,6 @@ const PatternViewContainer = () => {
         <label>結果</label>
         <input type="text" value={selected.result} readOnly={true} />
       </div>
-      <Button onClick={() => setDialogVisible(true)}>パターンを編集する</Button>
-      <label
-        onClick={() => {
-          dispatch(remove(selected.id))
-        }}
-      >
-        パターンを削除する
-      </label>
-
-      {dialogVisible && (
-        <PatternEditDialog
-          visible={dialogVisible}
-          onApply={onApplyCreation}
-          onCancel={onCancelCreation}
-        />
-      )}
     </div>
   )
 }

--- a/pattern-language-editor-client/src/views/containers/SideBarContainer.tsx
+++ b/pattern-language-editor-client/src/views/containers/SideBarContainer.tsx
@@ -1,22 +1,39 @@
 import React, { useState } from 'react'
+import { useDispatch } from 'react-redux'
 import PatternList from './PatternListContainer'
 import PatternCreateDialog from './PatternCreateDialogContainer'
+import PatternEditDialog from './PatternEditDialogContainer'
+import { remove } from '../../state/patterns'
 import { Box, Button } from '@mui/material'
 import AddIcon from '@mui/icons-material/Add'
 
 const SideBarContainer = () => {
-  const [dialogVisible, setDialogVisible] = useState(false)
+  const dispatch = useDispatch()
 
+  const [creationDialogVisible, setCreationDialogVisible] = useState(false)
   const onApplyCreation = (success: boolean) => {
     if (success) {
-      setDialogVisible(false)
+      setCreationDialogVisible(false)
     } else {
       // TODO: API失敗したら画面になんか出すとか
     }
   }
 
   const onCancelCreation = () => {
-    setDialogVisible(false)
+    setCreationDialogVisible(false)
+  }
+
+  const [editDialogVisible, setEditDialogVisible] = useState(false)
+  const onApplyEdit = (success: boolean) => {
+    if (success) {
+      setEditDialogVisible(false)
+    } else {
+      // TODO: API失敗したら画面になんか出すとか
+    }
+  }
+
+  const onCancelEdit = () => {
+    setEditDialogVisible(false)
   }
 
   return (
@@ -35,19 +52,34 @@ const SideBarContainer = () => {
           size="large"
           fullWidth
           onClick={() => {
-            setDialogVisible(true)
+            setCreationDialogVisible(true)
           }}
         >
           パターンを追加する
         </Button>
-        <PatternList />
+        <PatternList
+          onPatternEditClicked={() => {
+            setEditDialogVisible(true)
+          }}
+          onPatternRemoveClicked={(id: number) => {
+            dispatch(remove(id))
+          }}
+        />
       </Box>
 
-      {dialogVisible && (
+      {creationDialogVisible && (
         <PatternCreateDialog
-          visible={dialogVisible}
+          visible={creationDialogVisible}
           onApply={onApplyCreation}
           onCancel={onCancelCreation}
+        />
+      )}
+
+      {editDialogVisible && (
+        <PatternEditDialog
+          visible={editDialogVisible}
+          onApply={onApplyEdit}
+          onCancel={onCancelEdit}
         />
       )}
     </>


### PR DESCRIPTION
- 選択したパターンの編集、削除をサイドバーに表示するよう変更
- 上記に伴い、パターンビューから編集、削除ボタンを削除

![image](https://github.com/msntts/PatternLanguageEditor/assets/10500356/197bd80f-ed6a-4e6c-b788-727908d327ac)
